### PR TITLE
ARTS-396 Use local, rather than session, storage for tokens

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,16 +1,17 @@
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { OAuthModule } from 'angular-oauth2-oidc';
-import { environment } from 'src/environments/environment';
+import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { LandingPageComponent } from './landing-page/landing-page.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AuthenticationService, OAuth2AuthenticationService } from './services/oauth2-authentication.service';
+
+export function storageFactory(): OAuthStorage {
+  return localStorage;
+}
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { AuthenticationService, OAuth2AuthenticationService } from './services/o
     BrowserAnimationsModule,
   ],
   providers: [
+    { provide: OAuthStorage, useFactory: storageFactory },
     { provide: AuthenticationService, useClass: OAuth2AuthenticationService }
   ],
   bootstrap: [AppComponent]


### PR DESCRIPTION
## Description
Switch the angular oidc library to use local rather than session storage. Tokens can then be shared between tabs on the user's browser without requiring re-authentication each time

### Changes
- ARTS-396 Introduce and provide storage factory
