### PR TITLE
[ARTS-190] - UI tests around setting locale in a trial feature

### DIFF
--- a/src/assets/i18n/en-xx.json
+++ b/src/assets/i18n/en-xx.json
@@ -1,0 +1,13 @@
+{
+
+    "WELCOME": "xWelcome to the landing pagex",
+    "USER_LOGGED_IN": "xYou are logged in as mdp0x",
+    "USER_NOT_LOGGED_IN": "xYou are not logged as mdp0x.",
+    "HELLO": "xHello Hello Hellox",
+    "LANDING": "xLanding page Landing pagex",
+    "HOME_LINK_TEXT": "xHomex",
+    "ASSIGNED_SITES_LINK": "xAssigned Sitesx",
+    "LOGOUT": "xLogoutx",
+    "LOGIN": "xLoginx",
+    "ASSIGNED_SITES_TITLE": "xAssigned Sitesx"
+}

--- a/ui-tests/features/assignedSites.feature
+++ b/ui-tests/features/assignedSites.feature
@@ -1,3 +1,5 @@
+# author - Sameera Purini
+
 @smoketest @assignedSites @arts-48
 
 Feature: As a user

--- a/ui-tests/features/authenticationPage.feature
+++ b/ui-tests/features/authenticationPage.feature
@@ -1,3 +1,4 @@
+# author - Sameera Purini
 @smoketest @authenticationPage @arts-196 @arts-92 @arts-67
 Feature: As an authenticated user
     I want to automatically see the welcome page when navigating to the landing page

--- a/ui-tests/features/landingPage.feature
+++ b/ui-tests/features/landingPage.feature
@@ -1,4 +1,6 @@
-@smoketest @landingPage @arts-195 @arts-477
+# author - Sameera Purini
+
+@smoketest @landingPage @arts-195 @arts-477 @arts-190
 
 Feature: As a user
     I want to login to the system
@@ -15,6 +17,21 @@ Feature: As a user
         When a user is authenticated
         And user navigates to the landing or welcome page
         Then the welcome page message displays staffs information
+
+    @arts-190
+    Scenario:  Welcome Page has the locale set to English
+        And a default locale is set for the trial
+        And user can change the locale from the preferences
+        Then user can reset to default locale
+
+    @arts-190
+    Scenario: As a user I want to change my locale when working in my trial So that I can view my trial in my preferred locale
+        And User can succesfully logout of the session
+        When a regional user login to a specific trial
+        Then a default locale is set for the trial
+        And user can change the locale from the preferences
+        Then the settings is confirmed by checking the button text update
+
 
 
 

--- a/ui-tests/features/landingPage.feature
+++ b/ui-tests/features/landingPage.feature
@@ -25,13 +25,15 @@ Feature: As a user
         Then user can reset to default locale
 
     @arts-190
-    Scenario: As a user I want to change my locale when working in my trial So that I can view my trial in my preferred locale
+    Scenario Outline: As a user I want to change my locale when working in my trial So that I can view my trial in my preferred locale
         And User can succesfully logout of the session
         When a regional user login to a specific trial
         Then a default locale is set for the trial
         And user can change the locale from the preferences
-        Then the settings is confirmed by checking the button text update
-
+        Then the settings is confirmed by checking the button text "<buttontext>" update
+        Examples:
+            | buttontext |
+            | xLogoutx   |
 
 
 

--- a/ui-tests/pages/assignedSitesPage.page.js
+++ b/ui-tests/pages/assignedSitesPage.page.js
@@ -1,3 +1,5 @@
+/*  author - Sameera Purini */
+
 class assignedSitesPage {
 
     get assignedSites() { return $('//a[@href="/assigned-sites"]') }

--- a/ui-tests/pages/authenticationPage.page.js
+++ b/ui-tests/pages/authenticationPage.page.js
@@ -1,3 +1,4 @@
+/*  author - Sameera Purini */
 
 class authenticationPage {
 
@@ -8,6 +9,7 @@ class authenticationPage {
     get landingPageWelcomeMessage() { return $('//h1[text()="Welcome"]') }
     get selectYes() { return $('//input[@value="Yes"]') }
     get logOutButton() { return $('//div//button[text()="Logout"]') }
+    get localeLogOutButton() { return $('//div//button[text()="xLogoutx"]') }
     get selectAccountTologoutFrom() { return $('//div//small[text()="Signed in"]') }
     get errorMessage() { return $('//div[@id="usernameError"]') }
 

--- a/ui-tests/pages/landingPage.page.js
+++ b/ui-tests/pages/landingPage.page.js
@@ -1,12 +1,27 @@
+/*  author - Sameera Purini */
+
 class landingPage {
 
     get titleBar() { return $('.page-header') }
     get staffsName() { return $('//h2[text()]') }
     get loginButton() { return $('//button[@id="login_button"]') }
+    get defaultLocale() { return $('//span//div//select[@name="currentLocale"]//option[text()="English (UK)"]') }
+    get preferredLocale() { return $('//span//div//select[@name="currentLocale"]//option[@value="1: en-xx"]') }
+
 
     login() {
         this.loginButton.click()
     }
+
+    setLolcale() {
+        this.defaultLocale.click()
+        this.preferredLocale.click()
+    }
+
+    setDefaultLocale() {
+        this.defaultLocale.click()
+    }
+
 }
 
 module.exports = new landingPage();

--- a/ui-tests/pages/landingPage.page.js
+++ b/ui-tests/pages/landingPage.page.js
@@ -13,7 +13,7 @@ class landingPage {
         this.loginButton.click()
     }
 
-    setLolcale() {
+    setLocale() {
         this.defaultLocale.click()
         this.preferredLocale.click()
     }

--- a/ui-tests/steps/assignedSites.steps.js
+++ b/ui-tests/steps/assignedSites.steps.js
@@ -1,3 +1,5 @@
+/*  author - Sameera Purini */
+
 const { defineStep } = require('cucumber')
 const assignedSitesPage = require('../pages/assignedSitesPage.page.js')
 const landingPage = require('../pages/landingPage.page.js')

--- a/ui-tests/steps/authenticationPage.steps.js
+++ b/ui-tests/steps/authenticationPage.steps.js
@@ -1,3 +1,5 @@
+/*  author - Sameera Purini */
+
 const { defineStep } = require('cucumber')
 const landingPage = require('../pages/landingPage.page.js')
 const authenticationPage = require('../pages/authenticationPage.page.js')

--- a/ui-tests/steps/landingPage.steps.js
+++ b/ui-tests/steps/landingPage.steps.js
@@ -1,5 +1,6 @@
 const { defineStep } = require('cucumber')
 const landingPage = require('../pages/landingPage.page.js')
+const authenticationPage = require('../pages/authenticationPage.page.js')
 
 defineStep('the landing page displays the name of the trial', function () {
     let titleElement = landingPage.titleBar
@@ -15,5 +16,28 @@ defineStep('the welcome page message displays staffs information', function () {
     let staffsName = landingPage.staffsName
     expect(staffsName).toBeDisplayed()
 });
+
+defineStep('a default locale is set for the trial', function () {
+    let locale = landingPage.defaultLocale
+    expect(locale).toBeDisplayed()
+});
+
+defineStep('user can reset to default locale', function () {
+    landingPage.setDefaultLocale()
+});
+
+defineStep('user can change the locale from the preferences', function () {
+    landingPage.setLolcale()
+});
+
+defineStep('the settings is confirmed by checking the button text update', function () {
+    let localeLogOut = authenticationPage.localeLogOutButton
+    expect(localeLogOut.getText()).toEqual("xLogoutx")
+});
+
+
+
+
+
 
 

--- a/ui-tests/steps/landingPage.steps.js
+++ b/ui-tests/steps/landingPage.steps.js
@@ -1,3 +1,4 @@
+/*  author - Sameera Purini */
 const { defineStep } = require('cucumber')
 const landingPage = require('../pages/landingPage.page.js')
 const authenticationPage = require('../pages/authenticationPage.page.js')
@@ -27,10 +28,10 @@ defineStep('user can reset to default locale', function () {
 });
 
 defineStep('user can change the locale from the preferences', function () {
-    landingPage.setLolcale()
+    landingPage.setLocale()
 });
 
-defineStep('the settings is confirmed by checking the button text update', function () {
+defineStep('the settings is confirmed by checking the button text {string} update', function (string) {
     let localeLogOut = authenticationPage.localeLogOutButton
     expect(localeLogOut.getText()).toEqual("xLogoutx")
 });

--- a/ui-tests/steps/page.steps.js
+++ b/ui-tests/steps/page.steps.js
@@ -1,3 +1,4 @@
+/*  author - Sameera Purini */
 const { defineStep } = require('cucumber')
 const Page = require('../pages/page.js')
 


### PR DESCRIPTION
## Description
The PR has UI tests written in landing page feature that cover the acceptance criteria of arts-190 ticket. Scenarios have been added to the existing landing page feature in order to check both default and set locale from the drop down menu.
Also updated is all the features with author of the feature.

### Changes
- ARTS-190- Setting locale in a trial
