### PR TITLE
[ARTS-913] - Remove timeouts from ui tests

### DIFF
--- a/ui-tests/conf/wdio.conf.ci.js
+++ b/ui-tests/conf/wdio.conf.ci.js
@@ -26,7 +26,7 @@ exports.config = {
     //baseUrl: 'http:',
     //
     // Default timeout for all waitFor* commands.
-    waitforTimeout: 10000,
+    waitforTimeout: 60000,
     //
     // Default timeout in milliseconds for request
     // if browser driver or grid doesn't send response
@@ -34,12 +34,13 @@ exports.config = {
     //
     // Default request retries count
     connectionRetryCount: 3,
+    retries: 3,
     framework: 'cucumber',
 
     reporters: [
         ['junit', {
             outputDir: './test-results',
-            outputFileFormat: function(options) { // optional
+            outputFileFormat: function (options) { // optional
                 return `wdio-results-${options.cid}.xml`
             }
         }],
@@ -69,28 +70,28 @@ exports.config = {
 
     capabilities: [
         // {
-            // browserName: 'chrome',
-            // 'goog:chromeOptions': {
-            //     args: ['--headless', '--disable-gpu', '--no-sandbox'],
-            // }
-            {
-                // maxInstances can get overwritten per capability. So if you have an in house Selenium
-                // grid with only 5 firefox instance available you can make sure that not more than
-                // 5 instance gets started at a time.
-                maxInstances: 5,
-                browserName: 'firefox',
-                'moz:firefoxOptions': {
-                  // flag to activate Firefox headless mode (see https://github.com/mozilla/geckodriver/blob/master/README.md#firefox-capabilities for more details about moz:firefoxOptions)
-                  args: ['-headless']
-                },
-                // If outputDir is provided WebdriverIO can capture driver session logs
-                // it is possible to configure which logTypes to exclude.
-                // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
-                excludeDriverLogs: ['bugreport', 'server'],
-                //
-                // Parameter to ignore some or all Puppeteer default arguments
-                // ignoreDefaultArgs: ['-foreground'], // set value to true to ignore all default arguments
+        // browserName: 'chrome',
+        // 'goog:chromeOptions': {
+        //     args: ['--headless', '--disable-gpu', '--no-sandbox'],
+        // }
+        {
+            // maxInstances can get overwritten per capability. So if you have an in house Selenium
+            // grid with only 5 firefox instance available you can make sure that not more than
+            // 5 instance gets started at a time.
+            maxInstances: 5,
+            browserName: 'firefox',
+            'moz:firefoxOptions': {
+                // flag to activate Firefox headless mode (see https://github.com/mozilla/geckodriver/blob/master/README.md#firefox-capabilities for more details about moz:firefoxOptions)
+                args: ['-headless']
             },
+            // If outputDir is provided WebdriverIO can capture driver session logs
+            // it is possible to configure which logTypes to exclude.
+            // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+            excludeDriverLogs: ['bugreport', 'server'],
+            //
+            // Parameter to ignore some or all Puppeteer default arguments
+            // ignoreDefaultArgs: ['-foreground'], // set value to true to ignore all default arguments
+        },
     ],
     sync: true,
     logLevel: 'error',

--- a/ui-tests/conf/wdio.conf.js
+++ b/ui-tests/conf/wdio.conf.js
@@ -50,7 +50,7 @@ exports.config = {
 
 
     // Default timeout for all waitFor* commands.
-    waitforTimeout: 50000,
+    waitforTimeout: 60000,
     //
     // Default timeout in milliseconds for request
     // if browser driver or grid doesn't send response

--- a/ui-tests/features/assignedSites.feature
+++ b/ui-tests/features/assignedSites.feature
@@ -3,8 +3,8 @@
 @smoketest @assignedSites @arts-48
 
 Feature: As a user
-    I want to login to the system
-    so that I can carry out business functions for managing trial entities
+    I want to see a list of the trial sites I have been assigned to in my trial
+    So that I can understand which trial sites I can access
 
     Background: Navigate to the trial page
         Given User launches the trial page URL

--- a/ui-tests/pages/adminSitesPage.page.js
+++ b/ui-tests/pages/adminSitesPage.page.js
@@ -10,6 +10,7 @@ class adminSitesPage {
 
     adminSitesTab() {
         this.myadminSites.click();
+        browser.pause(10000)
     }
 
     popUp() {

--- a/ui-tests/pages/assignedSitesPage.page.js
+++ b/ui-tests/pages/assignedSitesPage.page.js
@@ -7,9 +7,8 @@ class assignedSitesPage {
     get region() { return $('//div//table//tr//td[text()="CCO"]') }
 
     assignedSitesTab() {
-        browser.pause(3000)
         this.assignedSites.click();
-        browser.pause(3000)
+        browser.pause(10000)
     }
 }
 module.exports = new assignedSitesPage();

--- a/ui-tests/pages/authenticationPage.page.js
+++ b/ui-tests/pages/authenticationPage.page.js
@@ -18,9 +18,7 @@ class authenticationPage {
         this.userName.setValue(process.env.AUTOMATION_USER_NAME)
         this.nextBtn.click()
         this.password.setValue(process.env.AUTOMATION_USER_PASSWORD)
-        browser.pause(6000)
         this.signIn.click()
-        browser.pause(9000)
         this.selectYes.click()
     }
 
@@ -28,9 +26,7 @@ class authenticationPage {
         this.userName.setValue(process.env.BOOTSTRAP_USER_NAME)
         this.nextBtn.click()
         this.password.setValue(process.env.BOOTSTRAP_USER_PASSWORD)
-        browser.pause(3000)
         this.signIn.click()
-        browser.pause(3000)
         this.selectYes.click()
     }
 
@@ -38,22 +34,16 @@ class authenticationPage {
         this.userName.setValue(process.env.QA_WITH_CREATE_USER_NAME)
         this.nextBtn.click()
         this.password.setValue(process.env.QA_WITH_CREATE_USER_PASSWORD)
-        browser.pause(3000)
         this.signIn.click()
-        browser.pause(3000)
         this.selectYes.click()
-        browser.pause(10000)
     }
 
     logOut() {
-        browser.pause(6000)
         this.logOutButton.click()
-        browser.pause(6000)
         this.selectAccountTologoutFrom.click()
     }
 
     invalidCredentials() {
-        browser.pause(3000)
         this.userName.setValue('automation@mtsdevndph.onmicrosoft.com')
         this.nextBtn.click()
     }


### PR DESCRIPTION
## Description
The PR removes the timeouts from ui tests, adds retries to the ui tests.

### Changes
- [ARTS-913] - Remove the timeouts used in the functions to use await / async.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-913]: https://ndph-arts.atlassian.net/browse/ARTS-913