### PR TITLE
Feature/arts 930

### DIFF
--- a/e2e-tests/pages/authenticationPage.page.js
+++ b/e2e-tests/pages/authenticationPage.page.js
@@ -40,7 +40,7 @@ class authenticationPage {
         this.password.setValue(process.env.QA_WITH_CREATE_USER_PASSWORD)
         browser.pause(3000)
         this.signIn.click()
-        browser.pause(3000)
+        browser.pause(13000)
         this.selectYes.click()
         browser.pause(10000)
     }

--- a/e2e-tests/pages/authenticationPage.page.js
+++ b/e2e-tests/pages/authenticationPage.page.js
@@ -30,7 +30,7 @@ class authenticationPage {
         this.password.setValue(process.env.BOOTSTRAP_USER_PASSWORD)
         browser.pause(3000)
         this.signIn.click()
-        browser.pause(3000)
+        browser.pause(13000)
         this.selectYes.click()
     }
 

--- a/src/app/admin-sites-page/admin-sites-page.component.spec.ts
+++ b/src/app/admin-sites-page/admin-sites-page.component.spec.ts
@@ -36,16 +36,18 @@ describe('AdminSitesPageComponent', () => {
   it('should fetch admin sites on init', fakeAsync(() => {
 
     const site: Site =
-      {name: '', alias: '', siteId: '123', parentSiteId: '456', parentSiteName: 'parent', siteType: '', description: '',
+      {name: '', alias: '', siteId: '123', parentSiteId: '456', parentSiteName: '', siteType: '', description: '',
         lastUpdated: '', status: ''};
     const sites: Site[] = [site];
 
     const adminSiteSpy = spyOn(siteService, 'getSitesByRole').withArgs('admin').and.returnValue(of(sites));
+    const siteWithIdSpy = spyOn(siteService, 'getSite').withArgs(site.parentSiteId).and.returnValue(of({} as Site));
+
     component.ngOnInit();
     tick();
     fixture.detectChanges();
 
     expect(adminSiteSpy).toHaveBeenCalled();
-
+    expect(siteWithIdSpy).toHaveBeenCalled();
   }));
 });

--- a/src/app/admin-sites-page/admin-sites-page.component.spec.ts
+++ b/src/app/admin-sites-page/admin-sites-page.component.spec.ts
@@ -36,18 +36,16 @@ describe('AdminSitesPageComponent', () => {
   it('should fetch admin sites on init', fakeAsync(() => {
 
     const site: Site =
-      {name: '', alias: '', siteId: '123', parentSiteId: '456', parentSiteName: '', siteType: '', description: '',
+      {name: '', alias: '', siteId: '123', parentSiteId: '456', parentSiteName: 'parent', siteType: '', description: '',
         lastUpdated: '', status: ''};
     const sites: Site[] = [site];
 
     const adminSiteSpy = spyOn(siteService, 'getSitesByRole').withArgs('admin').and.returnValue(of(sites));
-    const siteWithIdSpy = spyOn(siteService, 'getSite').withArgs(site.parentSiteId).and.returnValue(of({} as Site));
-
     component.ngOnInit();
     tick();
     fixture.detectChanges();
 
     expect(adminSiteSpy).toHaveBeenCalled();
-    expect(siteWithIdSpy).toHaveBeenCalled();
+
   }));
 });

--- a/src/app/admin-sites-page/admin-sites-page.component.ts
+++ b/src/app/admin-sites-page/admin-sites-page.component.ts
@@ -19,13 +19,6 @@ export class AdminSitesPageComponent implements OnInit {
     this.showModal = false;
     this.selectedSite = {};
     this.siteService.getSitesByRole('admin').pipe(first()).subscribe((sites) => {
-      sites.forEach(site => {
-        if (site.parentSiteId !== null) {
-          this.siteService.getSite(site.parentSiteId).subscribe((retSite: Site) => {
-            site.parentSiteName = retSite.name;
-          });
-        }
-      });
       this.sites = sites.sort((a, b) => a.name.localeCompare(b.name));
     });
   }

--- a/src/app/admin-sites-page/admin-sites-page.component.ts
+++ b/src/app/admin-sites-page/admin-sites-page.component.ts
@@ -19,6 +19,13 @@ export class AdminSitesPageComponent implements OnInit {
     this.showModal = false;
     this.selectedSite = {};
     this.siteService.getSitesByRole('admin').pipe(first()).subscribe((sites) => {
+      sites.forEach(site => {
+        if (site.parentSiteId !== null) {
+          this.siteService.getSite(site.parentSiteId).subscribe((retSite: Site) => {
+            site.parentSiteName = retSite.name;
+          });
+        }
+      });
       this.sites = sites.sort((a, b) => a.name.localeCompare(b.name));
     });
   }


### PR DESCRIPTION
Adding parentName to site model to save calling the site service for every site in the response

## Description
Adding parentName to site model to save calling the site service for every site in the response.

### Changes
- [ARTS-930] - Adding parentName to site model to save calling the site service for every site in the response.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-930]: https://ndph-arts.atlassian.net/browse/ARTS-930