### PR TITLE
[ARTS-933]

### DIFF
--- a/src/app/assigned-sites-page/assigned-sites-page.component.spec.ts
+++ b/src/app/assigned-sites-page/assigned-sites-page.component.spec.ts
@@ -33,7 +33,7 @@ describe('AssignedSitesPageComponent', () => {
   });
 
   it('should fetch assigned sites on init', () => {
-    const spy = spyOn(siteService, 'getSites').and.returnValue(of([]));
+    const spy = spyOn(siteService, 'getAssignedSites').and.returnValue(of([]));
 
     component.ngOnInit();
 

--- a/src/app/assigned-sites-page/assigned-sites-page.component.ts
+++ b/src/app/assigned-sites-page/assigned-sites-page.component.ts
@@ -13,8 +13,8 @@ export class AssignedSitesPageComponent implements OnInit {
   constructor(private siteService: SiteService) { }
 
   ngOnInit(): void {
-    this.siteService.getSites().pipe(first()).subscribe((sites) => {
-      this.sites = sites.sort();
+    this.siteService.getAssignedSites().pipe(first()).subscribe((sites) => {
+      this.sites = sites.sort((a, b) => a.siteName.localeCompare(b.siteName));
     });
   }
 }

--- a/src/app/components/sites-view/sites-view.component.html
+++ b/src/app/components/sites-view/sites-view.component.html
@@ -1,5 +1,5 @@
 <!-- <select class="form-control">
 </select> -->
 <table class="table table-striped">
-    <tr *ngFor="let site of sites" ><td>{{site.name}}</td></tr>
+    <tr *ngFor="let site of sites" ><td>{{site.siteName}}</td></tr>
 </table>

--- a/src/app/components/sites-view/sites-view.component.ts
+++ b/src/app/components/sites-view/sites-view.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Site } from 'src/app/model/site';
+import {SiteName} from '../../model/siteName';
 
 @Component({
   selector: 'app-sites-view',
@@ -7,7 +8,7 @@ import { Site } from 'src/app/model/site';
   styleUrls: ['./sites-view.component.sass']
 })
 export class SitesViewComponent {
-  @Input() sites: Site[] = [];
+  @Input() sites: SiteName[] = [];
 
   constructor() { }
 }

--- a/src/app/model/siteName.ts
+++ b/src/app/model/siteName.ts
@@ -1,0 +1,4 @@
+export interface SiteName {
+    siteName: string;
+    siteId: string;
+}

--- a/src/app/services/site.service.mock.ts
+++ b/src/app/services/site.service.mock.ts
@@ -1,8 +1,13 @@
 import { Observable, of } from 'rxjs';
 import { Site } from '../model/site';
+import {SiteName} from '../model/siteName';
 
 export class MockSiteService {
     getSites(): Observable <Site[]> {
+      return of([]);
+    }
+
+    getAssignedSites(): Observable <SiteName[]> {
       return of([]);
     }
 

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -4,6 +4,7 @@ import { Observable, of, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Site } from '../model/site';
 import { ConfigurationService } from './configuration-service';
+import { SiteName } from '../model/siteName';
 
 @Injectable({
   providedIn: 'root'
@@ -44,6 +45,11 @@ export class SiteService {
   getSitesByRole(role: string): Observable<Site[]> {
     const params = new HttpParams().set('role', role);
     return this.http.get<Site[]>(this.serviceUrl, {params})
+      .pipe(catchError(this.handleError));
+  }
+
+  getAssignedSites(): Observable <SiteName[]> {
+    return this.http.get<SiteName[]>(this.serviceUrl + '/' + 'assigned')
       .pipe(catchError(this.handleError));
   }
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,7 +11,7 @@ export const environment = {
   //  This URL is used during the PR UI test run; ensure that it points to
   //  a working environment during the PR process.
   //  This URL is overridden in the Azure deployment process
-  gatewayUrl: 'https://as-900test-sc-gateway-dev.azurewebsites.net/api',
+  gatewayUrl: 'https://as-arts930a-sc-gateway-dev.azurewebsites.net/api',
 };
 /*
  * For easier debugging in development mode, you can import the following file


### PR DESCRIPTION
Changing assigned sites to call new assigned sites endpoint and only receive a site name and site id.

## Description
Changing assigned sites to call new assigned sites endpoint and only receive a site name and site id.
This is reliant on the back-end change in MTS-Services, also named 933. This wont be merged until the back-end 
PR is merged. 

### Changes
- [ARTS-933] - Changing assigned sites to call new assigned sites endpoint and only receive a site name and site id.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-933]: https://ndph-arts.atlassian.net/browse/ARTS-933